### PR TITLE
fix canvas being selected

### DIFF
--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import style from './Canvas.module.css';
 import useCanvas from './useCanvas';
 
 function drawCircle(ctx, x, y, radius, fill, targetOn, isCenter) {
@@ -326,6 +327,7 @@ const Canvas = (props) => {
 
   return (
     <canvas
+      className={style.canvas}
       ref={canvasRef}
       onPointerMove={pointerHandler}
       onMouseMove={pointerHandler}

--- a/src/Canvas.module.css
+++ b/src/Canvas.module.css
@@ -1,0 +1,3 @@
+.canvas {
+  user-select: none;
+}


### PR DESCRIPTION
In the mouse or trackpad condition, dragging around the canvas may cause it to be selected (like text would be). This PR prevents this.